### PR TITLE
 Change example-percy-java-selenium to be a Java 8 project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This example app is an HTTP server that serves a fork of the [TodoMVC](https://g
 (forked at commit
 [c78ae12a1834a11da6236c64a0c0fb06b20b7c51](https://github.com/tastejs/todomvc/tree/c78ae12a1834a11da6236c64a0c0fb06b20b7c51)).
 
-It requires Java 11 and Maven >3.6.
+It requires Java 8 and Maven >3.6.
 
 The Selenium tests use ChromeDriver, which you need to install separately for your system.
 On Mac OS, you can use Homebrew:
@@ -32,6 +32,12 @@ Then visit http://localhost:8000 to see the app in action.
 To run the tests:
 ```bash
 $ mvn test
+```
+
+To install the Percy agent for this project, run `npm install`:
+
+```bash
+$ npm install
 ```
 
 To run Percy snapshots, first set the `PERCY_TOKEN` environment variable, and then run:

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-            <release>11</release>
+            <release>8</release>
           </configuration>
         </plugin>
       </plugins>

--- a/run_snapshots.sh
+++ b/run_snapshots.sh
@@ -3,4 +3,11 @@
 set -o pipefail
 set -e
 
+# If we don't have a local Percy agent binary, run npm install.
+if [ ! -f ./node_modules/.bin/percy ]; then
+  echo "*** Percy agent not installed. Installing now. ***"
+  npm install
+fi
+
+# Run the tests with snapshots.
 ./node_modules/.bin/percy exec -- mvn test

--- a/src/main/java/io/percy/examplepercyjavaselenium/App.java
+++ b/src/main/java/io/percy/examplepercyjavaselenium/App.java
@@ -67,7 +67,9 @@ public class App {
             response = "404 - File Not Found".getBytes();
             responseCode = 404;
         } else {
-            response = App.class.getClassLoader().getResourceAsStream(resourcePath).readAllBytes();
+            InputStream stream = App.class.getClassLoader().getResourceAsStream(resourcePath);
+            response = new byte[stream.available()];
+            stream.read(response);
             responseCode = 200;
         }
 


### PR DESCRIPTION
This also improves the `run_shapshots.sh` script to install the Percy agent if `npm install` hasn't been run.