### PR TITLE
ci: Fix pin Java version to 8 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ default_steps: &default_steps
     - checkout
     - run: sudo apt-get install maven
     # Get Java dependencies before trying to build tests.
-    - run: mvn dependency:go-offline
+    - run: mvn install
     # Installs @percy/agent
     - run: npm install
     - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,24 +3,24 @@ version: 2.1
 default_steps: &default_steps
   steps:
     - checkout
-    - run: sudo apt-get install maven
     # Get Java dependencies before trying to build tests.
-    - run: mvn install
+    - run: mvn dependency:go-offline
     # Installs @percy/agent
+    - run: node --version
     - run: npm install
     - run: npm test
 
 jobs:
   node_8:
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/openjdk:8u212-stretch-node-browsers-legacy
     environment:
       PERCY_ENABLE: 0
     <<: *default_steps
   node_10_with_percy:
     # We've opted this node version to be the one that runs and reports Percy's status
     docker:
-      - image: circleci/node:10-browsers
+      - image: circleci/openjdk:8u212-stretch-node-browsers-legacy
     <<: *default_steps
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,31 @@
 version: 2.1
-
-default_steps: &default_steps
-  steps:
-    - checkout
-    # Get Java dependencies before trying to build tests.
-    - run: mvn dependency:go-offline
-    # Installs @percy/agent
-    - run: node --version
-    - run: npm install
-    - run: npm test
-
 jobs:
   node_8:
     docker:
       - image: circleci/openjdk:8u212-stretch-node-browsers-legacy
     environment:
       PERCY_ENABLE: 0
-    <<: *default_steps
+    steps:
+      - run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+      - run: echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV && echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
+      - run: nvm install 8
+      - checkout
+      # Get Java dependencies before trying to build tests.
+      - run: mvn dependency:go-offline
+      # Installs @percy/agent
+      - run: npm install
+      - run: npm test
   node_10_with_percy:
     # We've opted this node version to be the one that runs and reports Percy's status
     docker:
       - image: circleci/openjdk:8u212-stretch-node-browsers-legacy
-    <<: *default_steps
+    steps:
+      - checkout
+      # Get Java dependencies before trying to build tests.
+      - run: mvn dependency:go-offline
+      # Installs @percy/agent
+      - run: npm install
+      - run: npm test
 
 workflows:
   version: 2


### PR DESCRIPTION
## What is this?

The version of Java installed on the node container we were using changed to Java 11 ~a month ago. That change broke our builds, so this PR uses a Java + node docker container (which defaults to node 10 & Java 8).

For the Node 8 step, I install NVM and install node 8 to test in. You can't merge two `steps` keys (as far as I know), so I just pulled the steps out into each version of node. A little duplication never hurts. 