### PR TITLE
Use HTTPS git cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm](https://nodejs.org/en/download/) and
 Clone the example application and install dependencies:
 
 ```bash
-$ git clone git@github.com:percy/example-percy-java-selenium.git
+$ git clone https://github.com/percy/example-percy-java-selenium.git
 $ cd example-percy-java-selenium
 $ make install
 ```


### PR DESCRIPTION
Resolves errors like this when cloning the repo:

```
$ git clone git@github.com:percy/example-percy-java-selenium.git
Cloning into 'example-percy-java-selenium'...
The authenticity of host 'github.com (XXX.XXX.XXX.XXX)' can't be established.
RSA key fingerprint is SHA256:XXXX.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,XXX.XXX.XXX.XXX' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

🎟️ [PER-1283](https://browserstack.atlassian.net/browse/PER-1283)