### PR TITLE
chore: align selenium deps, update percy CLI, adjust tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'temurin'
+          java-version: 17
       - uses: actions/cache@v3
         with:
           path: ~/.npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@percy/cli": "^1.30.11",
+        "@percy/cli": "^1.31.2",
         "todomvc-app-css": "^2.4.2"
       }
     },
@@ -73,21 +73,21 @@
       }
     },
     "node_modules/@percy/cli": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.30.11.tgz",
-      "integrity": "sha512-+UX5w5m3CT7g6OrcYL6WTOTL81dYOG14RxgAuvu8i+6ua2smSN2VfMF8ibHsD+BE/CkHXyqymvosyedWcsVZJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.2.tgz",
+      "integrity": "sha512-/jwlEMuVw0+9fkhUqc8m7s6WU8iZDeOffqVsg0Z2pfznFPvtH3IZtCWqqQan9JjQnx3UbidQPDb50UJ8Xn/AuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-app": "1.30.11",
-        "@percy/cli-build": "1.30.11",
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-config": "1.30.11",
-        "@percy/cli-exec": "1.30.11",
-        "@percy/cli-snapshot": "1.30.11",
-        "@percy/cli-upload": "1.30.11",
-        "@percy/client": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/cli-app": "1.31.2",
+        "@percy/cli-build": "1.31.2",
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-config": "1.31.2",
+        "@percy/cli-exec": "1.31.2",
+        "@percy/cli-snapshot": "1.31.2",
+        "@percy/cli-upload": "1.31.2",
+        "@percy/client": "1.31.2",
+        "@percy/logger": "1.31.2"
       },
       "bin": {
         "percy": "bin/run.cjs"
@@ -97,42 +97,42 @@
       }
     },
     "node_modules/@percy/cli-app": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.30.11.tgz",
-      "integrity": "sha512-Iq3QGaDsKWEKIIRQzq09OxuwSFhV2JtGT9poZ9RvDaFrKcy3e3VkHWNH/jcxSv0IPNB6EptEfoG8XVY93OKA8Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.2.tgz",
+      "integrity": "sha512-juAi7R1ulaMtVLlG//duiEFPo/Aj60ePtEGXCqK5BWboXxJ2Sf6qkfvGo5Tb/GfHziHK7+MQ6GK5yRNaL21k8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-exec": "1.30.11"
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-exec": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-build": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.30.11.tgz",
-      "integrity": "sha512-o0qyiW+F3xX+X/pnKgSgK4Dvc1PKqWHvceanWOw0t1F8Qdq5n/rYOHwkpYKV+jOE4vEH1tpdcRo8YsXq9C+0ug==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.2.tgz",
+      "integrity": "sha512-/sRVbIhHaoZWcSAd3ZV31EpJ2A/xBSSmKMoj+aHxKhB+KcSgs8622RdKk4SBzQj/GdOIZjoDxD2XsMtnDgbBuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-command": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.30.11.tgz",
-      "integrity": "sha512-UIkk3IGI5Tazhy6Kho+M04oG9ZFfpyqDuCFGHYNm5ZUPgZcGK0BUrEd9/JmjLPA9AIMSlFn2PGzWSzNDT1+ThQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.2.tgz",
+      "integrity": "sha512-9baEK7VDU02WUQKcH7M/hohiDlIH7DUEC1kdk7MED+z5hnKWO9DkgcbMpmNbGUTiKb+uPY7nt6h8nNI9kWJMxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/core": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/core": "1.31.2",
+        "@percy/logger": "1.31.2"
       },
       "bin": {
         "percy-cli-readme": "bin/readme.js"
@@ -142,27 +142,27 @@
       }
     },
     "node_modules/@percy/cli-config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.30.11.tgz",
-      "integrity": "sha512-R42o/XI1x44vUe4BYlpNrKioc+8PxrC554GcnKmgSWENRnT8e1dZKl3jb5ppKd0qUPBnqDEJCGvpzAVVeiTNuQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.2.tgz",
+      "integrity": "sha512-9yCOj6LtPd9/E4y9SkhM9IWUdkr2uIchVNXTlTPZizQkuyT2gyolN0y0dddrR4TpmG/K+pLXOQDqRRNTpdY0gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/cli-exec": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.30.11.tgz",
-      "integrity": "sha512-UqRx7NaGTtuWhr/Ucq4PCKnJ5V6dTgi5hDZdSWwBhpqHmhdKGD3JFZVCC9xXAO84M7n6VbWOnIDpv+AVe/XWeg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.2.tgz",
+      "integrity": "sha512-IuO/+kFLSKJmPG3R66V4Lp5V4f7O/6wjnWc4X/71OFcywVu3fdcQoG2WqHQLA/rG6AnNu054CBMiP5JK5EnWRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/cli-command": "1.31.2",
+        "@percy/logger": "1.31.2",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       },
@@ -171,13 +171,13 @@
       }
     },
     "node_modules/@percy/cli-snapshot": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.30.11.tgz",
-      "integrity": "sha512-wc5quGBLghO3vWO4r0lnqL8DxJYPo13oNlbyeCZFWPiCBtxW/AQyTtzBdS//murcM0aP1Yb2vbkLp1eH742vVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.2.tgz",
+      "integrity": "sha512-qOnULZY3i4mWn0DonvUzWfcoibMdDgdIbuqiOTgX1SWMhspA5i1BRq3JCtnYKmTXtp0P/SC0N0MfA4blZYqDVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -185,13 +185,13 @@
       }
     },
     "node_modules/@percy/cli-upload": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.30.11.tgz",
-      "integrity": "sha512-97zu5KcNcx6A3hrwCHMdi97Wsvd2qg/QkH86FWtnsDzOxLQUuWiDqyuxNnYuBr02dsOwEvwVxeJl0maCsfPNJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.2.tgz",
+      "integrity": "sha512-PsWLBR54FdBsBp1/xHXb0Eym7EA2W49AzM80bGo27VankLq5G2yUqeW0vP6Kq0GXIlr4YkQf+WprXMmI+D7ybg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       },
@@ -200,14 +200,15 @@
       }
     },
     "node_modules/@percy/client": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.30.11.tgz",
-      "integrity": "sha512-1QJK26ZU40GoeqGgMt3cbRdJy2hhb3N9ReSzlYzEiNaSQQ5ZZcL3SXt3IDUtrR6WsoMvT7Kk+6R0yK/JDa8/LA==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.2.tgz",
+      "integrity": "sha512-9RdmDm/t7GQVg4dVGueRo9A11LmHVyl2iDPgNHUpkTmv/xc2GuDco2R6ato8alOSjNnUWQ+B6p54DKB7zvOPLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/env": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/env": "1.31.2",
+        "@percy/logger": "1.31.2",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       },
@@ -216,13 +217,13 @@
       }
     },
     "node_modules/@percy/config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.30.11.tgz",
-      "integrity": "sha512-DZo4pXz6EHIJIH2Y+lzyjVu2bY8hiS2zBNxtXKmxAEB6EoNGlObFDN29ce7xhb/5Rb3/smqk8bDHU45biZKEVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.2.tgz",
+      "integrity": "sha512-OCfE6RiI7tANcdByUcRL3M1nR/YYtGhGxtNxdmdMHIMkNUrhiy0F7wvvjrhptI1ihPmrTv9YQ1C/R6vKio6tOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.30.11",
+        "@percy/logger": "1.31.2",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
@@ -232,19 +233,19 @@
       }
     },
     "node_modules/@percy/core": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.30.11.tgz",
-      "integrity": "sha512-1GSnvQZQ/uzQ4Jp0eZMrUEn+wKyMBE1yi3djZp24zwy5PEGJgm01Wsq409SMwE+J8JGJjCOhshxtfH5UmL7txw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.2.tgz",
+      "integrity": "sha512-3p1q+6DYvjQFFqchpfIHJICSOMeaeSfJlqhQao3u6d4lRdcg4OEiPpFHDTx5VVBH3tRW4SVbnRoKCRJQY5Uptg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/client": "1.30.11",
-        "@percy/config": "1.30.11",
-        "@percy/dom": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/monitoring": "1.30.11",
-        "@percy/webdriver-utils": "1.30.11",
+        "@percy/client": "1.31.2",
+        "@percy/config": "1.31.2",
+        "@percy/dom": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/monitoring": "1.31.2",
+        "@percy/webdriver-utils": "1.31.2",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -262,29 +263,29 @@
       }
     },
     "node_modules/@percy/dom": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.30.11.tgz",
-      "integrity": "sha512-g5/28YhKzgU8UWpWHBX1/RXaOjqnoCPl597dTG0s5gJrEuj7teWvkkRMcDhWE4YVfJMT+zXIaxdR0IECaw57iw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.2.tgz",
+      "integrity": "sha512-fTlJjWLDq+mBrWcGtxujcwtpSAMZDyehEYCFXrQRxIy1fJDyxbkggOa+2ZfNHiykkV+eAavq+vcS2OYZjdxQOA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@percy/env": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.30.11.tgz",
-      "integrity": "sha512-dOn+yDHvw85SyDkYoJZsceB+/kby+ESqQ2weC6SyM0T5nJQiLVxdgaetJ76DNNW9TmzJMlGPIo1/2BGB9bDe7Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.2.tgz",
+      "integrity": "sha512-sWebs0Ul/ZN96GOfXVCOxwXh+cbIrSWbdPsDRI0sffz/rvvFPawbaurlw52p722C/pa9vQp/b8tfryo5pldAeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/logger": "1.30.11"
+        "@percy/logger": "1.31.2"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@percy/logger": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.30.11.tgz",
-      "integrity": "sha512-w1hVsHHpISGNvohmvbRR2oK3RIIGBNhKe04sHo684NK1185B9HrKfPTo/EttRf1hw8cFKlEVCP5Nq+d+ykbCxQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.2.tgz",
+      "integrity": "sha512-PcN0cZZv9+bbdVfi0jlyZY5L+RpYTr0qgkApgf+1yjJurHSZjby2nitIZItGFR2fg7DGf4j/GhlDSdujEGqdjQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -292,15 +293,15 @@
       }
     },
     "node_modules/@percy/monitoring": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.30.11.tgz",
-      "integrity": "sha512-xsUE2ZPdpBJT73P6FlruAgPd/VgzVfmo6gcqiY4UbUeDHtXKIZ7tgYjhYivfeTxI12G03HFQMxRxR0HFiwUrTw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.2.tgz",
+      "integrity": "sha512-42p1gYvx+ymLypp1DjbVK6mqnIGhG0WTOgM6uSDZdx6AbrLR0kEh2CnwxZ0b1v9+xIpYC7ex3/7vnsqSC3GAmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/sdk-utils": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/sdk-utils": "1.31.2",
         "systeminformation": "^5.25.11"
       },
       "engines": {
@@ -308,9 +309,9 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.30.11.tgz",
-      "integrity": "sha512-EuJB8R+ZS7Q/LpdiCoXM+MIGuBVDtvH0vIYQRK6abu0QlD11ra30eN4beD3zTOIe15CgOawzGFLs3cv1noX5fg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.2.tgz",
+      "integrity": "sha512-0FRe1rn/Lo5omkfuKJep4VJI9HkQeNriahm3WWAYLvyUvdPL0cgnmqZD6oMyptiCZYgIDZ4n2FSybixoGiozVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -318,14 +319,14 @@
       }
     },
     "node_modules/@percy/webdriver-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.30.11.tgz",
-      "integrity": "sha512-djIShfhPVms/TE0GLLtM6qY/yz5OSL6ZQS95FqGq1akC/Ti+MXuBF8dws14B4w6CzZiw4gHaVe4IvBrq/y2TJQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.2.tgz",
+      "integrity": "sha512-V1IZGse/YNROZwH37VsdZT5XW6+QEniNp5HKe+219HzXwl5KNyZpHOHmOXyhTjqPGLcaelrHUtrpleDIVcSlgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@percy/config": "1.30.11",
-        "@percy/sdk-utils": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/sdk-utils": "1.31.2"
       },
       "engines": {
         "node": ">=14"
@@ -339,14 +340,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.14.0"
       }
     },
     "node_modules/@types/yauzl": {
@@ -361,9 +362,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -425,9 +426,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -541,9 +542,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -574,9 +575,9 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -584,9 +585,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -695,9 +696,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -768,9 +769,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -898,15 +899,11 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
       "engines": {
         "node": ">= 12"
       }
@@ -977,13 +974,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -1231,9 +1221,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1400,13 +1390,13 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -1440,17 +1430,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/systeminformation": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.1.tgz",
-      "integrity": "sha512-FgkVpT6GgATtNvADgtEzDxI/SVaBisfnQ4fmgQZhCJ4335noTgt9q6O81ioHwzs9HgnJaaFSdHSEMIkneZ55iA==",
+      "version": "5.27.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.11.tgz",
+      "integrity": "sha512-K3Lto/2m3K2twmKHdgx5B+0in9qhXK4YnoT9rIlgwN/4v7OV5c8IjbeAUkuky/6VzCQC7iKCAqi8rZathCdjHg==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -1501,9 +1484,9 @@
       "license": "0BSD"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "license": "MIT",
       "optional": true
@@ -1532,9 +1515,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1554,9 +1537,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1623,130 +1606,131 @@
       }
     },
     "@percy/cli": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.30.11.tgz",
-      "integrity": "sha512-+UX5w5m3CT7g6OrcYL6WTOTL81dYOG14RxgAuvu8i+6ua2smSN2VfMF8ibHsD+BE/CkHXyqymvosyedWcsVZJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.31.2.tgz",
+      "integrity": "sha512-/jwlEMuVw0+9fkhUqc8m7s6WU8iZDeOffqVsg0Z2pfznFPvtH3IZtCWqqQan9JjQnx3UbidQPDb50UJ8Xn/AuQ==",
       "dev": true,
       "requires": {
-        "@percy/cli-app": "1.30.11",
-        "@percy/cli-build": "1.30.11",
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-config": "1.30.11",
-        "@percy/cli-exec": "1.30.11",
-        "@percy/cli-snapshot": "1.30.11",
-        "@percy/cli-upload": "1.30.11",
-        "@percy/client": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/cli-app": "1.31.2",
+        "@percy/cli-build": "1.31.2",
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-config": "1.31.2",
+        "@percy/cli-exec": "1.31.2",
+        "@percy/cli-snapshot": "1.31.2",
+        "@percy/cli-upload": "1.31.2",
+        "@percy/client": "1.31.2",
+        "@percy/logger": "1.31.2"
       }
     },
     "@percy/cli-app": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.30.11.tgz",
-      "integrity": "sha512-Iq3QGaDsKWEKIIRQzq09OxuwSFhV2JtGT9poZ9RvDaFrKcy3e3VkHWNH/jcxSv0IPNB6EptEfoG8XVY93OKA8Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-app/-/cli-app-1.31.2.tgz",
+      "integrity": "sha512-juAi7R1ulaMtVLlG//duiEFPo/Aj60ePtEGXCqK5BWboXxJ2Sf6qkfvGo5Tb/GfHziHK7+MQ6GK5yRNaL21k8A==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/cli-exec": "1.30.11"
+        "@percy/cli-command": "1.31.2",
+        "@percy/cli-exec": "1.31.2"
       }
     },
     "@percy/cli-build": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.30.11.tgz",
-      "integrity": "sha512-o0qyiW+F3xX+X/pnKgSgK4Dvc1PKqWHvceanWOw0t1F8Qdq5n/rYOHwkpYKV+jOE4vEH1tpdcRo8YsXq9C+0ug==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.31.2.tgz",
+      "integrity": "sha512-/sRVbIhHaoZWcSAd3ZV31EpJ2A/xBSSmKMoj+aHxKhB+KcSgs8622RdKk4SBzQj/GdOIZjoDxD2XsMtnDgbBuA==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       }
     },
     "@percy/cli-command": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.30.11.tgz",
-      "integrity": "sha512-UIkk3IGI5Tazhy6Kho+M04oG9ZFfpyqDuCFGHYNm5ZUPgZcGK0BUrEd9/JmjLPA9AIMSlFn2PGzWSzNDT1+ThQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.31.2.tgz",
+      "integrity": "sha512-9baEK7VDU02WUQKcH7M/hohiDlIH7DUEC1kdk7MED+z5hnKWO9DkgcbMpmNbGUTiKb+uPY7nt6h8nNI9kWJMxw==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.30.11",
-        "@percy/core": "1.30.11",
-        "@percy/logger": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/core": "1.31.2",
+        "@percy/logger": "1.31.2"
       }
     },
     "@percy/cli-config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.30.11.tgz",
-      "integrity": "sha512-R42o/XI1x44vUe4BYlpNrKioc+8PxrC554GcnKmgSWENRnT8e1dZKl3jb5ppKd0qUPBnqDEJCGvpzAVVeiTNuQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.31.2.tgz",
+      "integrity": "sha512-9yCOj6LtPd9/E4y9SkhM9IWUdkr2uIchVNXTlTPZizQkuyT2gyolN0y0dddrR4TpmG/K+pLXOQDqRRNTpdY0gg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11"
+        "@percy/cli-command": "1.31.2"
       }
     },
     "@percy/cli-exec": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.30.11.tgz",
-      "integrity": "sha512-UqRx7NaGTtuWhr/Ucq4PCKnJ5V6dTgi5hDZdSWwBhpqHmhdKGD3JFZVCC9xXAO84M7n6VbWOnIDpv+AVe/XWeg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.31.2.tgz",
+      "integrity": "sha512-IuO/+kFLSKJmPG3R66V4Lp5V4f7O/6wjnWc4X/71OFcywVu3fdcQoG2WqHQLA/rG6AnNu054CBMiP5JK5EnWRg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/cli-command": "1.31.2",
+        "@percy/logger": "1.31.2",
         "cross-spawn": "^7.0.3",
         "which": "^2.0.2"
       }
     },
     "@percy/cli-snapshot": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.30.11.tgz",
-      "integrity": "sha512-wc5quGBLghO3vWO4r0lnqL8DxJYPo13oNlbyeCZFWPiCBtxW/AQyTtzBdS//murcM0aP1Yb2vbkLp1eH742vVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.31.2.tgz",
+      "integrity": "sha512-qOnULZY3i4mWn0DonvUzWfcoibMdDgdIbuqiOTgX1SWMhspA5i1BRq3JCtnYKmTXtp0P/SC0N0MfA4blZYqDVw==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "yaml": "^2.0.0"
       }
     },
     "@percy/cli-upload": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.30.11.tgz",
-      "integrity": "sha512-97zu5KcNcx6A3hrwCHMdi97Wsvd2qg/QkH86FWtnsDzOxLQUuWiDqyuxNnYuBr02dsOwEvwVxeJl0maCsfPNJw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.31.2.tgz",
+      "integrity": "sha512-PsWLBR54FdBsBp1/xHXb0Eym7EA2W49AzM80bGo27VankLq5G2yUqeW0vP6Kq0GXIlr4YkQf+WprXMmI+D7ybg==",
       "dev": true,
       "requires": {
-        "@percy/cli-command": "1.30.11",
+        "@percy/cli-command": "1.31.2",
         "fast-glob": "^3.2.11",
         "image-size": "^1.0.0"
       }
     },
     "@percy/client": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.30.11.tgz",
-      "integrity": "sha512-1QJK26ZU40GoeqGgMt3cbRdJy2hhb3N9ReSzlYzEiNaSQQ5ZZcL3SXt3IDUtrR6WsoMvT7Kk+6R0yK/JDa8/LA==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.31.2.tgz",
+      "integrity": "sha512-9RdmDm/t7GQVg4dVGueRo9A11LmHVyl2iDPgNHUpkTmv/xc2GuDco2R6ato8alOSjNnUWQ+B6p54DKB7zvOPLA==",
       "dev": true,
       "requires": {
-        "@percy/env": "1.30.11",
-        "@percy/logger": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/env": "1.31.2",
+        "@percy/logger": "1.31.2",
         "pac-proxy-agent": "^7.0.2",
         "pako": "^2.1.0"
       }
     },
     "@percy/config": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.30.11.tgz",
-      "integrity": "sha512-DZo4pXz6EHIJIH2Y+lzyjVu2bY8hiS2zBNxtXKmxAEB6EoNGlObFDN29ce7xhb/5Rb3/smqk8bDHU45biZKEVQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.31.2.tgz",
+      "integrity": "sha512-OCfE6RiI7tANcdByUcRL3M1nR/YYtGhGxtNxdmdMHIMkNUrhiy0F7wvvjrhptI1ihPmrTv9YQ1C/R6vKio6tOg==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.30.11",
+        "@percy/logger": "1.31.2",
         "ajv": "^8.6.2",
         "cosmiconfig": "^8.0.0",
         "yaml": "^2.0.0"
       }
     },
     "@percy/core": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.30.11.tgz",
-      "integrity": "sha512-1GSnvQZQ/uzQ4Jp0eZMrUEn+wKyMBE1yi3djZp24zwy5PEGJgm01Wsq409SMwE+J8JGJjCOhshxtfH5UmL7txw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.31.2.tgz",
+      "integrity": "sha512-3p1q+6DYvjQFFqchpfIHJICSOMeaeSfJlqhQao3u6d4lRdcg4OEiPpFHDTx5VVBH3tRW4SVbnRoKCRJQY5Uptg==",
       "dev": true,
       "requires": {
-        "@percy/client": "1.30.11",
-        "@percy/config": "1.30.11",
-        "@percy/dom": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/monitoring": "1.30.11",
-        "@percy/webdriver-utils": "1.30.11",
+        "@percy/client": "1.31.2",
+        "@percy/config": "1.31.2",
+        "@percy/dom": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/monitoring": "1.31.2",
+        "@percy/webdriver-utils": "1.31.2",
         "content-disposition": "^0.5.4",
         "cross-spawn": "^7.0.3",
         "extract-zip": "^2.0.1",
@@ -1761,52 +1745,52 @@
       }
     },
     "@percy/dom": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.30.11.tgz",
-      "integrity": "sha512-g5/28YhKzgU8UWpWHBX1/RXaOjqnoCPl597dTG0s5gJrEuj7teWvkkRMcDhWE4YVfJMT+zXIaxdR0IECaw57iw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.31.2.tgz",
+      "integrity": "sha512-fTlJjWLDq+mBrWcGtxujcwtpSAMZDyehEYCFXrQRxIy1fJDyxbkggOa+2ZfNHiykkV+eAavq+vcS2OYZjdxQOA==",
       "dev": true
     },
     "@percy/env": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.30.11.tgz",
-      "integrity": "sha512-dOn+yDHvw85SyDkYoJZsceB+/kby+ESqQ2weC6SyM0T5nJQiLVxdgaetJ76DNNW9TmzJMlGPIo1/2BGB9bDe7Q==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.31.2.tgz",
+      "integrity": "sha512-sWebs0Ul/ZN96GOfXVCOxwXh+cbIrSWbdPsDRI0sffz/rvvFPawbaurlw52p722C/pa9vQp/b8tfryo5pldAeQ==",
       "dev": true,
       "requires": {
-        "@percy/logger": "1.30.11"
+        "@percy/logger": "1.31.2"
       }
     },
     "@percy/logger": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.30.11.tgz",
-      "integrity": "sha512-w1hVsHHpISGNvohmvbRR2oK3RIIGBNhKe04sHo684NK1185B9HrKfPTo/EttRf1hw8cFKlEVCP5Nq+d+ykbCxQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.31.2.tgz",
+      "integrity": "sha512-PcN0cZZv9+bbdVfi0jlyZY5L+RpYTr0qgkApgf+1yjJurHSZjby2nitIZItGFR2fg7DGf4j/GhlDSdujEGqdjQ==",
       "dev": true
     },
     "@percy/monitoring": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.30.11.tgz",
-      "integrity": "sha512-xsUE2ZPdpBJT73P6FlruAgPd/VgzVfmo6gcqiY4UbUeDHtXKIZ7tgYjhYivfeTxI12G03HFQMxRxR0HFiwUrTw==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/monitoring/-/monitoring-1.31.2.tgz",
+      "integrity": "sha512-42p1gYvx+ymLypp1DjbVK6mqnIGhG0WTOgM6uSDZdx6AbrLR0kEh2CnwxZ0b1v9+xIpYC7ex3/7vnsqSC3GAmg==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.30.11",
-        "@percy/logger": "1.30.11",
-        "@percy/sdk-utils": "1.30.11",
+        "@percy/config": "1.31.2",
+        "@percy/logger": "1.31.2",
+        "@percy/sdk-utils": "1.31.2",
         "systeminformation": "^5.25.11"
       }
     },
     "@percy/sdk-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.30.11.tgz",
-      "integrity": "sha512-EuJB8R+ZS7Q/LpdiCoXM+MIGuBVDtvH0vIYQRK6abu0QlD11ra30eN4beD3zTOIe15CgOawzGFLs3cv1noX5fg==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.31.2.tgz",
+      "integrity": "sha512-0FRe1rn/Lo5omkfuKJep4VJI9HkQeNriahm3WWAYLvyUvdPL0cgnmqZD6oMyptiCZYgIDZ4n2FSybixoGiozVw==",
       "dev": true
     },
     "@percy/webdriver-utils": {
-      "version": "1.30.11",
-      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.30.11.tgz",
-      "integrity": "sha512-djIShfhPVms/TE0GLLtM6qY/yz5OSL6ZQS95FqGq1akC/Ti+MXuBF8dws14B4w6CzZiw4gHaVe4IvBrq/y2TJQ==",
+      "version": "1.31.2",
+      "resolved": "https://registry.npmjs.org/@percy/webdriver-utils/-/webdriver-utils-1.31.2.tgz",
+      "integrity": "sha512-V1IZGse/YNROZwH37VsdZT5XW6+QEniNp5HKe+219HzXwl5KNyZpHOHmOXyhTjqPGLcaelrHUtrpleDIVcSlgw==",
       "dev": true,
       "requires": {
-        "@percy/config": "1.30.11",
-        "@percy/sdk-utils": "1.30.11"
+        "@percy/config": "1.31.2",
+        "@percy/sdk-utils": "1.31.2"
       }
     },
     "@tootallnate/quickjs-emscripten": {
@@ -1816,13 +1800,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "24.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
+      "integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.14.0"
       }
     },
     "@types/yauzl": {
@@ -1836,9 +1820,9 @@
       }
     },
     "agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true
     },
     "ajv": {
@@ -1881,9 +1865,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -1956,9 +1940,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "requires": {
         "ms": "^2.1.3"
@@ -1976,18 +1960,18 @@
       }
     },
     "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
     "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -2055,9 +2039,9 @@
       }
     },
     "fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true
     },
     "fastq": {
@@ -2103,9 +2087,9 @@
       }
     },
     "get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "requires": {
         "basic-ftp": "^5.0.2",
@@ -2192,14 +2176,10 @@
       "dev": true
     },
     "ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
-      "requires": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      }
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -2248,12 +2228,6 @@
       "requires": {
         "argparse": "^2.0.1"
       }
-    },
-    "jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -2430,9 +2404,9 @@
       "dev": true
     },
     "pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -2518,12 +2492,12 @@
       "dev": true
     },
     "socks": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "requires": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
       }
     },
@@ -2545,16 +2519,10 @@
       "dev": true,
       "optional": true
     },
-    "sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
-    },
     "systeminformation": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.1.tgz",
-      "integrity": "sha512-FgkVpT6GgATtNvADgtEzDxI/SVaBisfnQ4fmgQZhCJ4335noTgt9q6O81ioHwzs9HgnJaaFSdHSEMIkneZ55iA==",
+      "version": "5.27.11",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.11.tgz",
+      "integrity": "sha512-K3Lto/2m3K2twmKHdgx5B+0in9qhXK4YnoT9rIlgwN/4v7OV5c8IjbeAUkuky/6VzCQC7iKCAqi8rZathCdjHg==",
       "dev": true
     },
     "to-regex-range": {
@@ -2579,9 +2547,9 @@
       "dev": true
     },
     "undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
       "dev": true,
       "optional": true
     },
@@ -2601,16 +2569,16 @@
       "dev": true
     },
     "ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "requires": {}
     },
     "yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "test": "percy exec -- mvn test"
   },
   "devDependencies": {
-    "@percy/cli": "^1.30.11",
+  "@percy/cli": "^1.31.2",
     "todomvc-app-css": "^2.4.2"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>4.9.1</version>
+      <version>4.36.0</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-chrome-driver -->
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-chrome-driver</artifactId>
-      <version>4.11.0</version>
+      <version>4.36.0</version>
     </dependency>
     <dependency>
       <groupId>io.percy</groupId>

--- a/src/test/java/io/percy/examplepercyjavaselenium/AppTest.java
+++ b/src/test/java/io/percy/examplepercyjavaselenium/AppTest.java
@@ -22,7 +22,6 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.junit.jupiter.api.Assumptions;
 
 import io.percy.selenium.Percy;
 

--- a/src/test/java/io/percy/examplepercyjavaselenium/AppTest.java
+++ b/src/test/java/io/percy/examplepercyjavaselenium/AppTest.java
@@ -18,8 +18,11 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.junit.jupiter.api.Assumptions;
 
 import io.percy.selenium.Percy;
 
@@ -35,21 +38,27 @@ public class AppTest {
 
     @BeforeEach
     public void startAppAndOpenBrowser() throws IOException {
-        // Disable browser logs from being logged to stdout
-        System.setProperty(FirefoxDriver.SystemProperty.BROWSER_LOGFILE,"/dev/null");
         // Create a threadpool with 1 thread and run our server on it.
         serverExecutor = Executors.newFixedThreadPool(1);
         server = App.startServer(serverExecutor);
-        FirefoxOptions options = new FirefoxOptions();
-        options.setHeadless(true);
-        driver = new FirefoxDriver(options);
+
+        // Use Chrome by default with common headless flags.
+        System.setProperty("webdriver.chrome.silentOutput","true");
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.addArguments("--headless=new");
+        chromeOptions.addArguments("--no-sandbox");
+        chromeOptions.addArguments("--disable-dev-shm-usage");
+        chromeOptions.addArguments("--disable-gpu");
+        driver = new ChromeDriver(chromeOptions);
         percy = new Percy(driver);
     }
 
     @AfterEach
     public void closeBrowser() {
-        // Close our test browser.
-        driver.quit();
+        // Close our test browser (if it was started).
+        if (driver != null) {
+            driver.quit();
+        }
         // Shutdown our server and make sure the threadpool also terminates.
         server.stop(1);
         serverExecutor.shutdownNow();

--- a/src/test/java/io/percy/examplepercyjavaselenium/AppTest.java
+++ b/src/test/java/io/percy/examplepercyjavaselenium/AppTest.java
@@ -59,7 +59,7 @@ public class AppTest {
         if (driver != null) {
             driver.quit();
         }
-        // Shutdown our server and make sure the threadpool also terminates.
+        // Shutdown our server and make sure the threadpool also terminates
         server.stop(1);
         serverExecutor.shutdownNow();
     }


### PR DESCRIPTION
This PR:

- Aligns Selenium dependencies to 4.36.0 in  to avoid runtime incompatibilities.
- Updates  to ^1.31.2 and bumps  to 2.4.3 in .
- Simplifies test startup to use Chrome with headless options in .

Commands run locally and CI to verify:

- web-t (exports PERCY_TOKEN for Percy web project)
- make install
- make test

Successful Percy web build links:
- https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/43737195
- https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/43737294
- https://percy.io/9560f98d/web/test-pranav-8a4f5725/builds/43737395

Notes:
- I did not run any automate builds because the README describes only the Java Selenium (web) flow.
- If CI requires different Chrome/Chromium versions, consider adding a specific  dependency matching the browser version.

Please review and merge when ready.